### PR TITLE
Add post title field alongside post text

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ app.post("/submit", (req, res) => {
 app.post("/edit", (req, res) => {
     const index = req.body.index;
     if(index >= 0 && index < postArray.length) {
-        res.render('edit.ejs', { post: postArray[index], index: index});
+        const post = postArray[index];
+
+        res.render('edit.ejs', 
+        { postTitle: post.title,
+          postText: post.text,
+          index: index});
     } else {
         res.redirect('error.ejs')
     }
@@ -36,9 +41,12 @@ app.post("/edit-submit", (req, res) => {
     const updatedPost = req.body.postText;
 
     if(index >= 0 && index < postArray.length) {
-        postArray[index] = updatedPost;
-    }
+        postArray[index].title = req.body.postTitle;
+        postArray[index].text = req.body.postText;
     res.redirect('/');
+    } else {
+    res.redirect('error.ejs') 
+    }
 })
 
 app.post("/delete", (req, res) => {

--- a/index.js
+++ b/index.js
@@ -12,8 +12,12 @@ app.get('/', (req, res) => {
 });
 
 app.post("/submit", (req, res) => {
+    console.log(req.body.postTitle);
     console.log(req.body.postText);
-    postArray.push(req.body.postText);
+    postArray.push({
+        title: req.body.postTitle,
+        text: req.body.postText,
+    });
     console.log(postArray);
     res.render('index.ejs', { postArray: postArray });
 })

--- a/views/edit.ejs
+++ b/views/edit.ejs
@@ -2,7 +2,8 @@
 
 <form action="/edit-submit" method="post">
     <input type="hidden" name="index" value="<%= locals.index %>">
-    <textarea name="postText"><%= locals.post %></textarea>
+    <textarea name="postTitle"><%= locals.postTitle %></textarea>
+    <textarea name="postText"><%= locals.postText %></textarea>
     <input type="submit" value="Save Changes">
 </form>
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -1,6 +1,7 @@
 <%- include("header") %>
 
 <form action="/submit" method="post">
+    <textarea name="postTitle" placeholder="Give your post a title"></textarea>
     <textarea name="postText" placeholder="Share your thoughts here!"></textarea>
     <input type="submit" value="Submit">
 </form>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -9,7 +9,8 @@
 <% if (locals.postArray) { %>
     <% postArray.forEach((post, index) => { %> 
         <div>
-            <%=post %>
+            <h2><%= post.title %></h2>
+            <p> <%= post.text %></p>
             <form action="/edit" method="post">
                 <input type="hidden" name="index" value="<%= index%>">
                 <input type="submit" value="Edit">


### PR DESCRIPTION
This PR demonstrates multiple fields (`title` and `text`) existing within post objects (still contained within `postArray`. It extends functionality for adding, editing and removing individual Array elements as existed previously, to allowing the same processes to occur for `title` and `text`. This demonstrates a route to expand to additional fields in future should I desire (e.g. automatically capturing post metadata such as datetime captured within a post object) - this will be beyond the scope of this mini capstone project, however. (I basically wanted to challenge myself to extend the previous functionality to two fields, rather than just one.)