### PR TITLE
css format blog posts

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,8 +1,21 @@
 .textarea-container{
-    display:grid;
+    display: grid;
     grid-template-columns: 500px;
     grid-template-rows: 25px 250px;
     row-gap: 20px;
     padding-bottom: 20px;
 
+}
+
+.post-view-container{
+    display: grid;
+    grid-template-columns: 500px;
+    grid-template-rows: 25px auto 25px;
+    row-gap: 20px;
+}
+
+.post-action-container{
+    display: grid;
+    grid-template-columns: 75px 75px;
+    grid-template-rows: 25px;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -21,8 +21,6 @@
                     <input type="hidden" name="index" value="<%= index %>">
                     <input type="submit" value="Edit">
                 </form>
-            </div>
-            <div class = "post-action-container">
                 <form action="/delete" method="post">
                     <input type="hidden" name="index" value="<%= index %>">
                     <input type="submit" value="Delete">


### PR DESCRIPTION
This PR
 - Sets height of post content to auto (but fixes width to 500px for the time being).
 - Utilises the `post-action-container` and `post-view-container` classes to apply grid layout formatting (ensuring stacked content, but with `edit` and `delete` buttons being side by side).