### PR TITLE
add universal bg colour and white text

### DIFF
--- a/public/styles/main.css
+++ b/public/styles/main.css
@@ -1,5 +1,7 @@
 html * {
     font-family: Arial, sans-serif !important;
+    background-color: #345995;
+    color: white;
 }
 
 .form-container{


### PR DESCRIPTION
This PR:
- Applies universal blue background colour scheme.
- Sets text to white by default (though this does not utilise `!important` so can be amended in child elements as required).