### PR TITLE
Prevent blank entries

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,20 +38,21 @@ app.post("/edit", (req, res) => {
           postText: post.text,
           index: index});
     } else {
-        res.redirect('error.ejs')
+        res.render('error.ejs')
     }
 })
 
 app.post("/edit-submit", (req, res) => {
     const index = req.body.index;
-    const updatedPost = req.body.postText;
+    const updatedTitle = req.body.postTitle;
+    const updatedText = req.body.postText;
 
-    if(index >= 0 && index < postArray.length) {
+    if(index >= 0 && index < postArray.length && updatedTitle.length > 0 && updatedText.length > 0) {
         postArray[index].title = req.body.postTitle;
         postArray[index].text = req.body.postText;
     res.redirect('/');
     } else {
-    res.redirect('error.ejs') 
+        res.render('error.ejs')
     }
 })
 

--- a/index.js
+++ b/index.js
@@ -15,10 +15,15 @@ app.get('/', (req, res) => {
 app.post("/submit", (req, res) => {
     console.log(req.body.postTitle);
     console.log(req.body.postText);
-    postArray.push({
-        title: req.body.postTitle,
-        text: req.body.postText,
-    });
+
+    if((req.body.postTitle.length == 0) || (req.body.postText.length == 0)){
+        console.log("User has attempted to enter a blank blog post, resetting page.")
+    } else {
+        postArray.push({
+            title: req.body.postTitle,
+            text: req.body.postText
+        }
+    )};
     console.log(postArray);
     res.render('index.ejs', { postArray: postArray });
 })


### PR DESCRIPTION
This PR
- Prevents blank entries on the main page.
- Renders `error.ejs` if the user attempts to submit an amended entry with blank content.

Blank entries are defined as those with either no title content or text content.